### PR TITLE
상품 검색 조건 변경

### DIFF
--- a/src/main/java/kr/co/gpgp/domain/common/Pages.java
+++ b/src/main/java/kr/co/gpgp/domain/common/Pages.java
@@ -1,4 +1,4 @@
-package kr.co.gpgp.web.common;
+package kr.co.gpgp.domain.common;
 
 import static java.util.stream.Collectors.*;
 

--- a/src/main/java/kr/co/gpgp/domain/item/ItemSearchCondition.java
+++ b/src/main/java/kr/co/gpgp/domain/item/ItemSearchCondition.java
@@ -7,14 +7,12 @@ import lombok.Getter;
 public class ItemSearchCondition {
 
     private String itemName;
-    private Integer priceGoe;
-    private Integer priceLoe;
+    private String author;
 
     @Builder
-    private ItemSearchCondition(String itemName, Integer priceGoe, Integer priceLoe) {
+    private ItemSearchCondition(String itemName, String author) {
         this.itemName = itemName;
-        this.priceGoe = priceGoe;
-        this.priceLoe = priceLoe;
+        this.author = author;
     }
 
 }

--- a/src/main/java/kr/co/gpgp/domain/item/ItemSearchCondition.java
+++ b/src/main/java/kr/co/gpgp/domain/item/ItemSearchCondition.java
@@ -1,18 +1,20 @@
 package kr.co.gpgp.domain.item;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class ItemSearchCondition {
 
-    private String itemName;
-    private String author;
+    private String itemNameOrAuthor;
 
-    @Builder
-    private ItemSearchCondition(String itemName, String author) {
-        this.itemName = itemName;
-        this.author = author;
+    private ItemSearchCondition(String itemNameOrAuthor) {
+        this.itemNameOrAuthor = itemNameOrAuthor;
+    }
+
+    public static ItemSearchCondition from(String itemNameOrAuthor) {
+        return new ItemSearchCondition(itemNameOrAuthor);
     }
 
 }

--- a/src/main/java/kr/co/gpgp/domain/item/ItemSearchDto.java
+++ b/src/main/java/kr/co/gpgp/domain/item/ItemSearchDto.java
@@ -2,14 +2,15 @@ package kr.co.gpgp.domain.item;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class ItemSearchDto {
 
     private Long itemId;
     private String itemName;
     private int itemPrice;
-
     private String author;
 
     @QueryProjection

--- a/src/main/java/kr/co/gpgp/domain/item/ItemSearchDto.java
+++ b/src/main/java/kr/co/gpgp/domain/item/ItemSearchDto.java
@@ -10,11 +10,14 @@ public class ItemSearchDto {
     private String itemName;
     private int itemPrice;
 
+    private String author;
+
     @QueryProjection
-    public ItemSearchDto(Long itemId, String itemName, int itemPrice) {
+    public ItemSearchDto(Long itemId, String itemName, int itemPrice, String author) {
         this.itemId = itemId;
         this.itemName = itemName;
         this.itemPrice = itemPrice;
+        this.author = author;
     }
 
 }

--- a/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
@@ -46,9 +46,9 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     }
 
     private List<ItemSearchDto> searchItemContent(ItemSearchCondition condition, Pageable pageable) {
-        QItemSearchDto itemSearchDto = new QItemSearchDto(item.id, item.info.name, item.price);
+        QItemSearchDto itemSearchDto = new QItemSearchDto(item.id, item.info.name, item.price, item.info.author);
         return queryFactory
-                .select( itemSearchDto)
+                .select(itemSearchDto)
                 .from(item)
                 .where(
                         itemNameContains(condition.getItemName()),
@@ -63,7 +63,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     }
 
     private BooleanExpression authorContains(String author) {
-        return StringUtils.hasText(author) ? item.info.author.contains(author) : null;
+        return StringUtils.hasText(author) ? item.info.author.contains(author):null;
     }
 
 }

--- a/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
@@ -42,8 +42,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 .from(item)
                 .where(
                         itemNameContains(condition.getItemName()),
-                        priceGoe(condition.getPriceGoe()),
-                        priceLoe(condition.getPriceLoe()));
+                        authorContains(condition.getAuthor()));
     }
 
     private List<ItemSearchDto> searchItemContent(ItemSearchCondition condition, Pageable pageable) {
@@ -53,8 +52,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 .from(item)
                 .where(
                         itemNameContains(condition.getItemName()),
-                        priceGoe(condition.getPriceGoe()),
-                        priceLoe(condition.getPriceLoe()))
+                        authorContains(condition.getAuthor()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -64,12 +62,8 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
         return StringUtils.hasText(itemName) ? item.info.name.contains(itemName):null;
     }
 
-    private BooleanExpression priceGoe(Integer priceGoe) {
-        return priceGoe!=null ? item.price.goe(priceGoe):null;
-    }
-
-    private BooleanExpression priceLoe(Integer priceLoe) {
-        return priceLoe!=null ? item.price.loe(priceLoe):null;
+    private BooleanExpression authorContains(String author) {
+        return StringUtils.hasText(author) ? item.info.author.contains(author) : null;
     }
 
 }

--- a/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
@@ -1,17 +1,11 @@
 package kr.co.gpgp.repository.item;
 
-import static com.querydsl.core.types.dsl.Expressions.asNumber;
 import static kr.co.gpgp.domain.item.QItem.item;
 
-import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import kr.co.gpgp.domain.item.Item;
 import kr.co.gpgp.domain.item.ItemSearchCondition;
 import kr.co.gpgp.domain.item.ItemSearchDto;
 import kr.co.gpgp.domain.item.QItemSearchDto;
@@ -40,9 +34,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
         return queryFactory
                 .select(item.count())
                 .from(item)
-                .where(
-                        itemNameContains(condition.getItemName()),
-                        authorContains(condition.getAuthor()));
+                .where(containsCondition(condition.getItemNameOrAuthor()));
     }
 
     private List<ItemSearchDto> searchItemContent(ItemSearchCondition condition, Pageable pageable) {
@@ -51,19 +43,22 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 .select(itemSearchDto)
                 .from(item)
                 .where(
-                        itemNameContains(condition.getItemName()),
-                        authorContains(condition.getAuthor()))
+                        containsCondition(condition.getItemNameOrAuthor()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
     }
 
+    private BooleanExpression containsCondition(String condition) {
+        return StringUtils.hasText(condition) ? itemNameContains(condition).or(authorContains(condition)): null;
+    }
+
     private BooleanExpression itemNameContains(String itemName) {
-        return StringUtils.hasText(itemName) ? item.info.name.contains(itemName):null;
+        return item.info.name.contains(itemName);
     }
 
     private BooleanExpression authorContains(String author) {
-        return StringUtils.hasText(author) ? item.info.author.contains(author):null;
+        return item.info.author.contains(author);
     }
 
 }

--- a/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/gpgp/repository/item/ItemRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import kr.co.gpgp.domain.item.ItemSearchCondition;
 import kr.co.gpgp.domain.item.ItemSearchDto;
 import kr.co.gpgp.domain.item.QItemSearchDto;
@@ -14,7 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
@@ -50,7 +50,8 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     }
 
     private BooleanExpression containsCondition(String condition) {
-        return StringUtils.hasText(condition) ? itemNameContains(condition).or(authorContains(condition)): null;
+        String nullSafeCondition = Optional.ofNullable(condition).orElse("");
+        return itemNameContains(nullSafeCondition).or(authorContains(nullSafeCondition));
     }
 
     private BooleanExpression itemNameContains(String itemName) {

--- a/src/main/java/kr/co/gpgp/web/api/item/ItemController.java
+++ b/src/main/java/kr/co/gpgp/web/api/item/ItemController.java
@@ -1,18 +1,15 @@
 package kr.co.gpgp.web.api.item;
 
-import java.util.List;
-import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import kr.co.gpgp.auth.dto.UserDetails;
 import kr.co.gpgp.domain.item.Item;
 import kr.co.gpgp.domain.item.ItemCommandService;
 import kr.co.gpgp.domain.item.ItemFindService;
 import kr.co.gpgp.domain.item.ItemSearchCondition;
-import kr.co.gpgp.domain.item.ItemSearchCondition.ItemSearchConditionBuilder;
 import kr.co.gpgp.domain.item.ItemSearchDto;
 import kr.co.gpgp.domain.user.Seller;
 import kr.co.gpgp.domain.user.SellerService;
-import kr.co.gpgp.web.common.Pages;
+import kr.co.gpgp.domain.common.Pages;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -78,24 +75,21 @@ public class ItemController {
         return "redirect:/";
     }
 
-    @GetMapping("/list")
+    @GetMapping
     public String searchItem(
-            @RequestParam(required = false) String itemName,
+            @RequestParam(required = false) String condition,
             Pageable pageable,
             Model model
     ) {
-        ItemSearchCondition condition = ItemSearchCondition.builder()
-                .itemName(itemName)
-                .build();
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), 10);
-        Page<ItemSearchDto> searchItems = itemFindService.search(condition, pageRequest);
-
+        ItemSearchCondition searchCondition = ItemSearchCondition.from(condition);
+        Page<ItemSearchDto> searchItems = itemFindService.search(searchCondition, pageRequest);
         model.addAttribute("searchItems", searchItems);
 
         Pages<ItemSearchDto> pages = Pages.of(searchItems, 4);
-
         model.addAttribute("pages", pages.getPages());
 
+        log.info("condition='{}'", condition);
         log.info("pages.getPages()= '{}'", pages.getPages());
         log.info("firstPage='{}'", pages.getFirstPage());
         log.info("lastPage='{}'", pages.getLastPage());

--- a/src/main/resources/templates/items/list.mustache
+++ b/src/main/resources/templates/items/list.mustache
@@ -5,7 +5,7 @@
   <div>
     <form action method="get">
       <label for="name">책 검색</label>
-      <input type="text" class="form-control", name="itemName">
+      <input type="text" class="form-control", name="condition">
     </form>
   </div>
 
@@ -14,6 +14,7 @@
     <tr>
       <th>도서 명</th>
       <th>가격</th>
+      <th>저자</th>
     </tr>
     </thead>
     <tbody>
@@ -21,6 +22,7 @@
       <tr>
         <td>{{itemName}}</td>
         <td>{{itemPrice}}</td>
+        <td>{{author}}</td>
       </tr>
     {{/searchItems}}
     </tbody>

--- a/src/test/java/kr/co/gpgp/domain/item/ItemFindServiceTest.java
+++ b/src/test/java/kr/co/gpgp/domain/item/ItemFindServiceTest.java
@@ -59,9 +59,7 @@ class ItemFindServiceTest {
             itemJpaRepository.save(item);
         }
 
-        ItemSearchCondition condition = ItemSearchCondition.builder()
-                .itemName("i")
-                .build();
+        ItemSearchCondition condition = ItemSearchCondition.from("1");
 
         // when
         int PageSize = 10;

--- a/src/test/java/kr/co/gpgp/repository/item/ItemJpaRepositoryCustomTests.java
+++ b/src/test/java/kr/co/gpgp/repository/item/ItemJpaRepositoryCustomTests.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 class ItemJpaRepositoryCustomTests {
 
     @Autowired
-    private ItemRepositoryCustom sut;
+    private ItemRepositoryCustomImpl sut;
 
     @Autowired
     private ItemJpaRepository itemJpaRepository;
@@ -41,9 +41,7 @@ class ItemJpaRepositoryCustomTests {
             itemJpaRepository.save(item);
         }
 
-        ItemSearchCondition condition = ItemSearchCondition.builder()
-                .itemName("i")
-                .build();
+        ItemSearchCondition condition = ItemSearchCondition.from("1");
 
         // when
         int PageSize = 10;


### PR DESCRIPTION
작업
- 상품 검색 조건을 `상품명`과 `저자`로 변경
- 상품 검색 조건 변경에 따라 리포지토리, 검색 조건 객체 수정

추가 작업이 필요한 점
- 현재 상품 컨트롤러에 상품 목록 보여주는 url 엔드 포인트를 `/items` 로 했는데 상품 등록 url 엔드 포인트랑 겹침. 그래서 상품 등록 url 엔드 포인트를 등록 `/items/registration` 로 변경할 예정